### PR TITLE
Clients transfer too much money to strangers

### DIFF
--- a/paramFiles/clientsProfiles.csv
+++ b/paramFiles/clientsProfiles.csv
@@ -1,4 +1,4 @@
-action,maxCount,minCount,averageAmount,stdAmount,freq
+action,minCount,maxCount,averageAmount,stdAmount,freq
 CASH_IN,1,1,121136.63,0,0.07869
 CASH_IN,2,2,101944.59,59537.83,0.03256
 CASH_IN,3,3,108129.39,86582.83,0.01928

--- a/src/main/java/org/paysim/parameters/Parameters.java
+++ b/src/main/java/org/paysim/parameters/Parameters.java
@@ -15,7 +15,8 @@ public class Parameters {
     public final int nbClients, nbMerchants, nbBanks, nbFraudsters, nbSteps;
     public final double multiplier, transferLimit;
     public final float thirdPartyNewVictimProbability;
-    public final double firstPartyFraudProbability, merchantReuseProbability,
+    public final double firstPartyFraudProbability, clientReuseProbability,
+            clientAcquaintanceProbability, merchantReuseProbability,
             thirdPartyFraudProbability, thirdPartyPercentHighRiskMerchants;
     public final String aggregatedTransactions, maxOccurrencesPerClient, initialBalancesDistribution,
             overdraftLimits, clientsProfilesFile, transactionsTypes;
@@ -59,6 +60,10 @@ public class Parameters {
 
         // XXX: 0.9 based on some Python simulations. May change this later.
         merchantReuseProbability = Double.parseDouble(props.getProperty("merchantReuseProbability", "0.9"));
+
+        // XXX: wags
+        clientReuseProbability = Double.parseDouble(props.getProperty("clientReuseProbability", "0.9"));
+        clientAcquaintanceProbability = Double.parseDouble(props.getProperty("clientAcquaintanceProbability", "0.9"));
 
         String nvp = props.getProperty("thirdPartyNewVictimProbability");
         if (nvp == null || nvp.equals("0.4")) {


### PR DESCRIPTION
Clients need friends in this world. This is a prototype of trying to add
some affinity like previously done between Clients and Merchants.

2 new params:
- clientReuseProbability: probability of picking a friend to send money
  to when doing a Transfer
- clientAcquaintanceProbability: probability that a picked Client for a
  Transfer will be considered a "friend" for the future

Modeling idea is to capture how most money transfers are between
acquaintances and only occasionally to "strangers." Similar to how
Clients now "favor" Merchants, providing some locality concept.